### PR TITLE
コメント機能の追加

### DIFF
--- a/prisma/migrations/20230604075201_add_comments/migration.sql
+++ b/prisma/migrations/20230604075201_add_comments/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE `Comment` (
+    `id` VARCHAR(191) NOT NULL,
+    `body` VARCHAR(191) NOT NULL,
+    `authorId` VARCHAR(191) NOT NULL,
+    `postId` VARCHAR(191) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Comment` ADD CONSTRAINT `Comment_authorId_fkey` FOREIGN KEY (`authorId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Comment` ADD CONSTRAINT `Comment_postId_fkey` FOREIGN KEY (`postId`) REFERENCES `Post`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,11 +12,12 @@ datasource db {
 }
 
 model User {
-  id       String @id @default(uuid())
-  email    String @unique
+  id       String   @id @default(uuid())
+  email    String   @unique
   name     String
   password String
   posts    Post[]
+  comments Comment[]
 }
 
 model Post {
@@ -28,4 +29,16 @@ model Post {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   author      User     @relation(fields: [authorId], references: [id])
+  comments    Comment[]
+}
+
+model Comment {
+  id        String   @id @default(uuid())
+  body      String
+  authorId  String
+  postId    String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  author    User     @relation(fields: [authorId], references: [id])
+  post      Post     @relation(fields: [postId], references: [id])
 }

--- a/src/application/dto/comment/CommentCreateDto.ts
+++ b/src/application/dto/comment/CommentCreateDto.ts
@@ -1,0 +1,5 @@
+export interface CommentCreateDto {
+    body: string;
+    authorId: string;
+    postId: string;
+}

--- a/src/application/dto/comment/CommentResponseDto.ts
+++ b/src/application/dto/comment/CommentResponseDto.ts
@@ -1,0 +1,9 @@
+export interface CommentResponseDto {
+    id: string;
+    body: string;
+    authorId: string;
+    authorName: string;
+    postId: string;
+    createdAt?: string;
+    updatedAt?: string;
+  }

--- a/src/application/dto/comment/CommentUpdateDto.ts
+++ b/src/application/dto/comment/CommentUpdateDto.ts
@@ -1,0 +1,3 @@
+export interface CommentUpdateDto {
+    body: string;
+}

--- a/src/application/services/CommentService.ts
+++ b/src/application/services/CommentService.ts
@@ -1,0 +1,102 @@
+import { Comment } from '../../domain/entities/Comment'
+import { CommentBody } from '../../domain/vo/CommentBody'
+import { CommentId } from '../../domain/vo/CommentId'
+import { PostId } from '../../domain/vo/PostId'
+import { UserId } from '../../domain/vo/UserId'
+import { CommentRepository } from '../../infrastructure/repositories/CommentRepository'
+import { v4 as uuidv4 } from 'uuid'
+import { UserRepository } from '../../infrastructure/repositories/UserRepository'
+import { CommentResponseDto } from '../dto/comment/CommentResponseDto'
+import { CommentCreateDto } from '../dto/comment/CommentCreateDto'
+import { CommentUpdateDto } from '../dto/comment/CommentUpdateDto'
+import { User } from '../../domain/entities/User'
+
+export class CommentService {
+  constructor(
+    private commentRepository: CommentRepository,
+    private userRepository: UserRepository
+  ) {}
+
+private toDto(comment: Comment, authorName: string): CommentResponseDto {
+    return {
+      id: comment.id.value,
+      body: comment.body.value,
+      authorId: comment.authorId.value,
+      authorName: authorName,
+      postId: comment.postId.value,
+      createdAt: comment.createdAt?.toISOString(),
+      updatedAt: comment.updatedAt?.toISOString(),
+    }
+  }
+
+  async getCommentsByPostId(id: PostId): Promise<CommentResponseDto[]> {
+    const comments = await this.commentRepository.findCommentsByPostId(id)
+
+    const authorIds = comments.map((comment) => comment.authorId)
+    const users = await this.userRepository.findUsersByIds(authorIds)
+
+    const userMap = new Map()
+    users.forEach((user) => userMap.set(user.id.value, user.name.value))
+
+    return comments.map((comment) => {
+      const authorName = userMap.get(comment.authorId.value) ?? 'Unknown'
+      return this.toDto(comment, authorName)
+    })
+  }
+  async getCommentByCommentId(id: CommentId): Promise<CommentResponseDto> {
+    const comment = await this.commentRepository.findById(id)
+    if (!comment) {
+      throw new Error('Comment not found')
+    }
+    const user = await this.getUserByUserId(comment.authorId);
+
+    return this.toDto(comment, user.name.value)
+  }
+
+  async createComment(commentDto: CommentCreateDto): Promise<CommentResponseDto> {
+    const comment = new Comment(
+      new CommentId(uuidv4()),
+      new CommentBody(commentDto.body),
+      new UserId(commentDto.authorId),
+      new PostId(commentDto.postId)
+    )
+    const savedComment = await this.commentRepository.save(comment)
+    const user = await this.getUserByUserId(comment.authorId);
+
+    return this.toDto(savedComment, user.name.value)
+  }
+
+  async updateComment(
+    id: CommentId,
+    commentDto: CommentUpdateDto
+  ): Promise<CommentResponseDto> {
+    const comment = await this.commentRepository.findById(id)
+    if (!comment) {
+      throw new Error('Comment not found')
+    }
+
+    const updatedComment = comment.updateWithDto(commentDto);
+    const savedComment = await this.commentRepository.save(updatedComment);
+    const user = await this.getUserByUserId(comment.authorId);
+
+    return this.toDto(savedComment, user.name.value)
+  }
+
+  async deleteComment(id: CommentId): Promise<void> {
+    const comment = await this.commentRepository.findById(id)
+    if (!comment) {
+      throw new Error('Comment not found')
+    }
+
+    await this.commentRepository.delete(id)
+  }
+
+  private async getUserByUserId(userId: UserId): Promise<User> {
+    const user = await this.userRepository.find(userId);
+    if (!user) {
+      throw new Error('User not found');
+    }
+    return user;
+  }
+  
+}

--- a/src/domain/entities/Comment.ts
+++ b/src/domain/entities/Comment.ts
@@ -1,13 +1,15 @@
-import { CommentBody } from '../vo/CommentBody'
-import { CommentId } from '../vo/CommentId'
-import { PostId } from '../vo/PostId'
-import { UserId } from '../vo/UserId'
+import { CommentBody } from "../vo/CommentBody";
+import { CommentId } from "../vo/CommentId";
+import { PostId } from "../vo/PostId";
+import { UserId } from "../vo/UserId";
 
 export class Comment {
-  private _id: CommentId
-  private _body: CommentBody
-  private _authorId: UserId
-  private _postId: PostId
+  private _id: CommentId;
+  private _body: CommentBody;
+  private _authorId: UserId;
+  private _postId: PostId;
+  private _createdAt?: Date;
+  private _updatedAt?: Date;
 
   constructor(
     id: CommentId,
@@ -15,25 +17,44 @@ export class Comment {
     authorId: UserId,
     postId: PostId
   ) {
-    this._id = id
-    this._body = body
-    this._authorId = authorId
-    this._postId = postId
+    this._id = id;
+    this._body = body;
+    this._authorId = authorId;
+    this._postId = postId;
+    // _createdAt and _updatedAt will be set when the instance is saved to the database.
   }
 
-  get id() {
-    return this._id
+  // Getters
+  get id(): CommentId {
+    return this._id;
   }
 
-  get body() {
-    return this._body
+  get body(): CommentBody {
+    return this._body;
   }
 
-  get authorId() {
-    return this._authorId
+  get authorId(): UserId {
+    return this._authorId;
   }
 
-  get postId() {
-    return this._postId
+  get postId(): PostId {
+    return this._postId;
+  }
+
+  get createdAt() {
+    return this._createdAt;
+  }
+
+  get updatedAt() {
+    return this._updatedAt;
+  }
+
+  // Setters
+  setCreatedAt(createdAt: Date): void {
+    this._createdAt = createdAt;
+  }
+
+  setUpdatedAt(updatedAt: Date): void {
+    this._updatedAt = updatedAt;
   }
 }

--- a/src/domain/entities/Comment.ts
+++ b/src/domain/entities/Comment.ts
@@ -1,3 +1,4 @@
+import { CommentUpdateDto } from "../../application/dto/comment/CommentUpdateDto";
 import { CommentBody } from "../vo/CommentBody";
 import { CommentId } from "../vo/CommentId";
 import { PostId } from "../vo/PostId";
@@ -22,6 +23,23 @@ export class Comment {
     this._authorId = authorId;
     this._postId = postId;
     // _createdAt and _updatedAt will be set when the instance is saved to the database.
+  }
+
+  updateWithDto(dto: CommentUpdateDto): Comment {
+    const updatedPost = new Comment(
+      this._id,
+      new CommentBody(dto.body),
+      this._authorId,
+      this._postId
+    )
+
+    if (this._createdAt !== undefined) {
+      updatedPost.setCreatedAt(this._createdAt)
+    }
+
+    updatedPost.setUpdatedAt(new Date())
+
+    return updatedPost
   }
 
   // Getters

--- a/src/domain/repositories/ICommentRepository.ts
+++ b/src/domain/repositories/ICommentRepository.ts
@@ -1,0 +1,10 @@
+import { Comment } from "../entities/Comment";
+import { CommentId } from "../vo/CommentId";
+import { PostId } from "../vo/PostId";
+
+export interface ICommentRepository {
+  findAllByPostId(postId: PostId): Promise<Comment[]>;
+  findById(id: CommentId): Promise<Comment | null>;
+  save(comment: Comment): Promise<Comment>;
+  delete(id: CommentId): Promise<void>;
+}

--- a/src/infrastructure/repositories/CommentRepository.ts
+++ b/src/infrastructure/repositories/CommentRepository.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, Comment as PrismaComment } from "@prisma/client";
 import { PostId } from "../../domain/vo/PostId";
 import { CommentId } from "../../domain/vo/CommentId";
 import { ICommentRepository } from "../../domain/repositories/ICommentRepository";
@@ -19,7 +19,7 @@ export class CommentRepository implements ICommentRepository {
       where: { postId: postId.value },
     });
 
-    return results.map(result => this.toEntitiy(result));
+    return results.map(result => this.toEntity(result));
   }
 
   async findById(id: CommentId): Promise<Comment | null> {
@@ -31,7 +31,7 @@ export class CommentRepository implements ICommentRepository {
       return null;
     }
 
-    return this.toEntitiy(result);
+    return this.toEntity(result);
   }
 
   async save(comment: Comment): Promise<Comment> {
@@ -55,7 +55,7 @@ export class CommentRepository implements ICommentRepository {
       },
     });
 
-    return this.toEntitiy(savedRecord);
+    return this.toEntity(savedRecord);
   }
 
   async delete(id: CommentId): Promise<void> {
@@ -64,15 +64,16 @@ export class CommentRepository implements ICommentRepository {
     });
   }
 
-  private toEntitiy(commentRecord: any): Comment {
+  private toEntity(prismaComment: PrismaComment): Comment {
     const comment = new Comment(
-      new CommentId(commentRecord.id),
-      new CommentBody(commentRecord.body),
-      new UserId(commentRecord.authorId),
-      new PostId(commentRecord.postId)
+      new CommentId(prismaComment.id),
+      new CommentBody(prismaComment.body),
+      new UserId(prismaComment.authorId),
+      new PostId(prismaComment.postId)
     );
-    comment.setCreatedAt(new Date(commentRecord.createdAt));
-    comment.setUpdatedAt(new Date(commentRecord.updatedAt));
+    comment.setCreatedAt(new Date(prismaComment.createdAt));
+    comment.setUpdatedAt(new Date(prismaComment.updatedAt));
     return comment;
   }
+  
 }

--- a/src/infrastructure/repositories/CommentRepository.ts
+++ b/src/infrastructure/repositories/CommentRepository.ts
@@ -1,0 +1,78 @@
+import { PrismaClient } from "@prisma/client";
+import { PostId } from "../../domain/vo/PostId";
+import { CommentId } from "../../domain/vo/CommentId";
+import { ICommentRepository } from "../../domain/repositories/ICommentRepository";
+import { CommentBody } from "../../domain/vo/CommentBody";
+import { UserId } from "../../domain/vo/UserId";
+import { Comment } from "../../domain/entities/Comment"
+
+
+export class CommentRepository implements ICommentRepository {
+  private prisma: PrismaClient;
+
+  constructor(prisma: PrismaClient) {
+    this.prisma = prisma;
+  }
+
+  async findAllByPostId(postId: PostId): Promise<Comment[]> {
+    const results = await this.prisma.comment.findMany({
+      where: { postId: postId.value },
+    });
+
+    return results.map(result => this.toEntitiy(result));
+  }
+
+  async findById(id: CommentId): Promise<Comment | null> {
+    const result = await this.prisma.comment.findUnique({
+      where: { id: id.value },
+    });
+
+    if (result == null) {
+      return null;
+    }
+
+    return this.toEntitiy(result);
+  }
+
+  async save(comment: Comment): Promise<Comment> {
+    const { id, body, authorId, postId } = comment;
+
+    const savedRecord = await this.prisma.comment.upsert({
+      where: { id: id.value },
+      update: {
+        body: body.value,
+        authorId: authorId.value,
+        postId: postId.value,
+        updatedAt: new Date(),
+      },
+      create: {
+        id: id.value,
+        body: body.value,
+        authorId: authorId.value,
+        postId: postId.value,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    return this.toEntitiy(savedRecord);
+  }
+
+  async delete(id: CommentId): Promise<void> {
+    await this.prisma.comment.delete({
+      where: { id: id.value },
+    });
+  }
+
+  private toEntitiy(commentRecord: any): Comment {
+    const comment = new Comment(
+      new CommentId(commentRecord.id),
+      new CommentBody(commentRecord.body),
+      new UserId(commentRecord.authorId),
+      new PostId(commentRecord.postId)
+    );
+    comment.setCreatedAt(new Date(commentRecord.createdAt));
+    comment.setUpdatedAt(new Date(commentRecord.updatedAt));
+    return comment;
+  }
+}

--- a/src/infrastructure/repositories/CommentRepository.ts
+++ b/src/infrastructure/repositories/CommentRepository.ts
@@ -75,5 +75,13 @@ export class CommentRepository implements ICommentRepository {
     comment.setUpdatedAt(new Date(prismaComment.updatedAt));
     return comment;
   }
-  
+
+  async findCommentsByPostId(postId: PostId): Promise<Comment[]> {
+    const prismaComments = await this.prisma.comment.findMany({
+      where: {
+        postId: postId.value,
+      },
+    })
+    return prismaComments.map(this.toEntity)
+  }
 }

--- a/src/presentation/controller/CommentController.ts
+++ b/src/presentation/controller/CommentController.ts
@@ -1,0 +1,71 @@
+import { Request, Response } from 'express';
+import { CommentService } from '../../application/services/CommentService';
+import { PostId } from '../../domain/vo/PostId';
+import { CommentId } from '../../domain/vo/CommentId';
+import { CommentCreateDto } from '../../application/dto/comment/CommentCreateDto';
+import { CommentUpdateDto } from '../../application/dto/comment/CommentUpdateDto';
+
+export class CommentController {
+  constructor(private commentService: CommentService) {}
+
+  async getCommentsByPostId(req: Request, res: Response): Promise<void> {
+    try {
+      const postId = new PostId(req.params.postId)
+      const comments = await this.commentService.getCommentsByPostId(postId)
+      res.json(comments)
+    } catch (err) {
+      res
+        .status(400)
+        .json({ error: err instanceof Error ? err.message : String(err) })
+    }
+  }
+
+  async getCommentById(req: Request, res: Response): Promise<void> {
+    try {
+      const id = new CommentId(req.params.id)
+      const comment = await this.commentService.getCommentByCommentId(id)
+      res.json(comment)
+    } catch (err) {
+      res
+        .status(400)
+        .json({ error: err instanceof Error ? err.message : String(err) })
+    }
+  }
+
+  async createComment(req: Request, res: Response): Promise<void> {
+    try {
+      const commentDto = req.body as CommentCreateDto
+      const comment = await this.commentService.createComment(commentDto)
+      res.status(201).json(comment)
+    } catch (err) {
+      res
+        .status(400)
+        .json({ error: err instanceof Error ? err.message : String(err) })
+    }
+  }
+
+  async updateComment(req: Request, res: Response): Promise<void> {
+    try {
+      const id = new CommentId(req.params.id)
+      const commentDto = req.body as CommentUpdateDto
+      const comment = await this.commentService.updateComment(id, commentDto)
+      res.json(comment)
+    } catch (err) {
+      res
+        .status(400)
+        .json({ error: err instanceof Error ? err.message : String(err) })
+    }
+  }
+
+  async deleteComment(req: Request, res: Response): Promise<void> {
+    try {
+      const id = new CommentId(req.params.id)
+      await this.commentService.deleteComment(id)
+      res.sendStatus(204)
+    } catch (err) {
+      res
+        .status(400)
+        .json({ error: err instanceof Error ? err.message : String(err) })
+    }
+  }
+}

--- a/test/application/services/CommentService.test.ts
+++ b/test/application/services/CommentService.test.ts
@@ -1,0 +1,165 @@
+import { PrismaClient } from "@prisma/client";
+import { CommentService } from "../../../src/application/services/CommentService";
+import { CommentRepository } from "../../../src/infrastructure/repositories/CommentRepository";
+import { UserRepository } from "../../../src/infrastructure/repositories/UserRepository";
+import { CommentId } from "../../../src/domain/vo/CommentId";
+import { CommentBody } from "../../../src/domain/vo/CommentBody";
+import { UserId } from "../../../src/domain/vo/UserId";
+import { PostId } from "../../../src/domain/vo/PostId";
+import { User } from "../../../src/domain/entities/User";
+import { Name } from "../../../src/domain/vo/Name";
+import { Email } from "../../../src/domain/vo/Email";
+import { Password } from "../../../src/domain/vo/Password";
+import { Comment } from "../../../src/domain/entities/Comment";
+import { CommentCreateDto } from "../../../src/application/dto/comment/CommentCreateDto";
+import { CommentUpdateDto } from "../../../src/application/dto/comment/CommentUpdateDto";
+
+
+jest.mock('@prisma/client', () => {
+    return {
+      PrismaClient: jest.fn().mockImplementation(() => {
+        return {
+          post: {
+            findUnique: jest.fn(),
+            upsert: jest.fn(),
+            delete: jest.fn(),
+            findMany: jest.fn(),
+          },
+        }
+      }),
+    }
+  })
+
+describe('CommentService', () => {
+  let prisma: PrismaClient;
+  let commentService: CommentService;
+  let commentRepository: CommentRepository;
+  let userRepository: UserRepository;
+  let comment: Comment;
+  let user: User;
+
+  beforeEach(() => {
+    commentRepository = new CommentRepository(prisma);
+    userRepository = new UserRepository(prisma);
+    commentService = new CommentService(commentRepository, userRepository);
+
+    comment = new Comment(
+      new CommentId('someId'),
+      new CommentBody('Test Comment'),
+      new UserId('testAuthorId'),
+      new PostId('testPostId')
+    );
+
+    user = new User(
+      new UserId('testAuthorId'),
+      new Name('Test User'),
+      new Email('test@example.com'),
+      new Password('password')
+    );
+  });
+
+  describe('getCommentsByPostId', () => {
+    it('should return comments with author names for given post id', async () => {
+      jest.spyOn(commentRepository, 'findCommentsByPostId').mockResolvedValue([comment]);
+      jest.spyOn(userRepository, 'findUsersByIds').mockResolvedValue([user]);
+
+      const result = await commentService.getCommentsByPostId(comment.postId);
+
+      expect(result).toEqual([{
+        id: comment.id.value,
+        body: comment.body.value,
+        authorId: comment.authorId.value,
+        authorName: user.name.value,
+        postId: comment.postId.value,
+        createdAt: comment.createdAt?.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(),
+      }]);
+    });
+  });
+
+  describe('getCommentByCommentId', () => {
+    it('should return a comment for the given comment id', async () => {
+      jest.spyOn(commentRepository, 'findById').mockResolvedValue(comment);
+      jest.spyOn(userRepository, 'find').mockResolvedValue(user);
+
+      const result = await commentService.getCommentByCommentId(comment.id);
+
+      expect(result).toEqual({
+        id: comment.id.value,
+        body: comment.body.value,
+        authorId: comment.authorId.value,
+        authorName: user.name.value,
+        postId: comment.postId.value,
+        createdAt: comment.createdAt?.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(),
+      });
+    });
+  });
+
+  describe('createComment', () => {
+    it('should create a comment and return it', async () => {
+      const commentCreateDto: CommentCreateDto = {
+        body: 'Test Comment',
+        authorId: 'testAuthorId',
+        postId: 'testPostId'
+      };
+
+      jest.spyOn(commentRepository, 'save').mockResolvedValue(comment);
+      jest.spyOn(userRepository, 'find').mockResolvedValue(user);
+
+      const result = await commentService.createComment(commentCreateDto);
+
+      expect(result).toEqual({
+        id: comment.id.value,
+        body: comment.body.value,
+        authorId: comment.authorId.value,
+        authorName: user.name.value,
+        postId: comment.postId.value,
+        createdAt: comment.createdAt?.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(),
+      });
+    });
+  });
+
+  describe('updateComment', () => {
+    it('should update a comment and return it', async () => {
+      const commentUpdateDto: CommentUpdateDto = {
+        body: 'Updated Comment',
+      };
+
+      const updatedComment = new Comment(
+        comment.id,
+        new CommentBody(commentUpdateDto.body as string),
+        comment.authorId,
+        comment.postId
+      );
+
+      jest.spyOn(commentRepository, 'findById').mockResolvedValue(comment);
+      jest.spyOn(commentRepository, 'save').mockResolvedValue(updatedComment);
+      jest.spyOn(userRepository, 'find').mockResolvedValue(user);
+
+      const result = await commentService.updateComment(comment.id, commentUpdateDto);
+
+      expect(result).toEqual({
+        id: updatedComment.id.value,
+        body: updatedComment.body.value,
+        authorId: updatedComment.authorId.value,
+        authorName: user.name.value,
+        postId: updatedComment.postId.value,
+        createdAt: updatedComment.createdAt?.toISOString(),
+        updatedAt: updatedComment.updatedAt?.toISOString(),
+      });
+    });
+  });
+
+  describe('deleteComment', () => {
+    it('should delete a comment', async () => {
+      jest.spyOn(commentRepository, 'findById').mockResolvedValue(comment);
+      jest.spyOn(commentRepository, 'delete').mockResolvedValue();
+
+      await commentService.deleteComment(comment.id);
+
+      expect(commentRepository.delete).toHaveBeenCalledWith(comment.id);
+    });
+  });
+});

--- a/test/infrastructure/CommentRepository.test.ts
+++ b/test/infrastructure/CommentRepository.test.ts
@@ -1,0 +1,113 @@
+import { PrismaClient } from "@prisma/client";
+import { Comment } from '../../src/domain/entities/Comment';
+import { CommentRepository } from '../../src/infrastructure/repositories/CommentRepository';
+import { CommentId } from "../../src/domain/vo/CommentId";
+import { CommentBody } from "../../src/domain/vo/CommentBody";
+import { UserId } from "../../src/domain/vo/UserId";
+import { PostId } from "../../src/domain/vo/PostId";
+
+
+jest.mock('@prisma/client', () => {
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => {
+      return {
+        comment: {
+          findMany: jest.fn(),
+          findUnique: jest.fn(),
+          upsert: jest.fn(),
+          delete: jest.fn(),
+        },
+      };
+    }),
+  };
+});
+
+describe('CommentRepository', () => {
+  let commentRepository: CommentRepository;
+  let prisma: PrismaClient;
+  let timestamp: Date;
+  let comment: Comment;
+
+  beforeEach(() => {
+    prisma = new PrismaClient();
+    commentRepository = new CommentRepository(prisma);
+    timestamp = new Date();
+    comment = new Comment(
+      new CommentId('testCommentId'),
+      new CommentBody('test body'),
+      new UserId('testAuthorId'),
+      new PostId('testPostId'),
+    );
+    comment.setCreatedAt(timestamp);
+    comment.setUpdatedAt(timestamp);
+  });
+
+  describe('findAllByPostId', () => {
+    it('should return all comments by post ID', async () => {
+      jest.spyOn(prisma.comment, 'findMany').mockResolvedValue([{
+        id: comment.id.value,
+        authorId: comment.authorId.value,
+        body: comment.body.value,
+        postId: comment.postId.value,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      }]);
+
+      const comments = await commentRepository.findAllByPostId(comment.postId);
+
+      expect(comments).toEqual([comment]);
+    });
+  });
+
+  describe('findById', () => {
+    it('should return the comment if it exists', async () => {
+      jest.spyOn(prisma.comment, 'findUnique').mockResolvedValue({
+        id: comment.id.value,
+        authorId: comment.authorId.value,
+        body: comment.body.value,
+        postId: comment.postId.value,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+
+      const foundComment = await commentRepository.findById(comment.id);
+
+      expect(foundComment).toEqual(comment);
+    });
+
+    it('should return null if the comment does not exist', async () => {
+      jest.spyOn(prisma.comment, 'findUnique').mockResolvedValue(null);
+
+      const foundComment = await commentRepository.findById(new CommentId('nonexistentId'));
+
+      expect(foundComment).toBeNull();
+    });
+  });
+
+  describe('save', () => {
+    it('should save the comment and return it', async () => {
+      jest.spyOn(prisma.comment, 'upsert').mockResolvedValue({
+        id: comment.id.value,
+        authorId: comment.authorId.value,
+        body: comment.body.value,
+        postId: comment.postId.value,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+
+      const savedComment = await commentRepository.save(comment);
+
+      expect(savedComment).toEqual(comment);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete the comment', async () => {
+      const mockDelete = jest.spyOn(prisma.comment, 'delete');
+
+      await commentRepository.delete(comment.id);
+
+      expect(mockDelete).toHaveBeenCalledWith({ where: { id: comment.id.value } });
+    });
+  });
+});

--- a/test/presentation/controller/CommentController.test.ts
+++ b/test/presentation/controller/CommentController.test.ts
@@ -1,0 +1,171 @@
+import { Request, Response } from 'express'
+import { mock, MockProxy } from 'jest-mock-extended'
+import { CommentService } from '../../../src/application/services/CommentService'
+import { CommentController } from '../../../src/presentation/controller/CommentController'
+
+let commentService: MockProxy<CommentService> & CommentService
+let commentController: CommentController
+let mockRequest: Partial<Request>
+let mockResponse: Partial<Response>
+
+beforeEach(() => {
+  commentService = mock<CommentService>()
+  commentController = new CommentController(commentService)
+  mockRequest = {}
+  mockResponse = {
+    json: jest.fn().mockReturnThis(),
+    status: jest.fn().mockReturnThis(),
+    sendStatus: jest.fn().mockReturnThis(),
+  }
+})
+
+describe('CommentController', () => {
+  describe('getCommentsByPostId', () => {
+    it('should retrieve all comments for a post and return status 200', async () => {
+      mockRequest.params = { postId: 'postId123' }
+      await commentController.getCommentsByPostId(
+        mockRequest as Request,
+        mockResponse as Response
+      )
+      expect(mockResponse.json).toHaveBeenCalled()
+    })
+
+    it('should handle error when retrieving comments for a post', async () => {
+      commentService.getCommentsByPostId.mockRejectedValue(new Error('Get comments error'))
+      mockRequest.params = { postId: 'postId123' }
+
+      await commentController.getCommentsByPostId(
+        mockRequest as Request,
+        mockResponse as Response
+      )
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400)
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: 'Get comments error',
+      })
+    })
+  })
+
+  describe('getCommentById', () => {
+    it('should retrieve a comment and return status 200', async () => {
+      mockRequest.params = { id: 'commentId123' }
+      await commentController.getCommentById(
+        mockRequest as Request,
+        mockResponse as Response
+      )
+      expect(mockResponse.json).toHaveBeenCalled()
+    })
+
+    it('should handle error when getting a comment', async () => {
+      commentService.getCommentByCommentId.mockRejectedValue(new Error('Get comment error'))
+      mockRequest.params = { id: 'commentId123' }
+
+      await commentController.getCommentById(
+        mockRequest as Request,
+        mockResponse as Response
+      )
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400)
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: 'Get comment error',
+      })
+    })
+  })
+
+  describe('createComment', () => {
+    it('should create a comment and return status 201', async () => {
+      mockRequest.body = {
+        postId: 'postId123',
+        content: 'Test Content',
+        authorId: 'testAuthorId',
+      }
+      await commentController.createComment(
+        mockRequest as Request,
+        mockResponse as Response
+      )
+      expect(mockResponse.status).toHaveBeenCalledWith(201)
+      expect(mockResponse.json).toHaveBeenCalled()
+    })
+
+    it('should handle error when creating a comment', async () => {
+      commentService.createComment.mockRejectedValue(new Error('Create comment error'))
+      mockRequest.body = {
+        postId: 'postId123',
+        content: 'Test Content',
+        authorId: 'testAuthorId',
+      }
+
+      await commentController.createComment(
+        mockRequest as Request,
+        mockResponse as Response
+      )
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400)
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: 'Create comment error',
+      })
+    })
+  })
+
+  describe('updateComment', () => {
+    it('should update a comment and return status 200', async () => {
+      mockRequest.params = { id: 'commentId123' }
+      mockRequest.body = {
+        postId: 'postId123',
+        content: 'Updated Content',
+        authorId: 'testAuthorId',
+      }
+      await commentController.updateComment(
+        mockRequest as Request,
+        mockResponse as Response
+      )
+      expect(mockResponse.json).toHaveBeenCalled()
+    })
+
+    it('should handle error when updating a comment', async () => {
+      commentService.updateComment.mockRejectedValue(new Error('Update comment error'))
+      mockRequest.params = { id: 'commentId123' }
+      mockRequest.body = {
+        postId: 'postId123',
+        content: 'Updated Content',
+        authorId: 'testAuthorId',
+      }
+
+      await commentController.updateComment(
+        mockRequest as Request,
+        mockResponse as Response
+      )
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400)
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: 'Update comment error',
+      })
+    })
+  })
+
+  describe('deleteComment', () => {
+    it('should delete a comment and return status 204', async () => {
+      mockRequest.params = { id: 'commentId123' }
+      await commentController.deleteComment(
+        mockRequest as Request,
+        mockResponse as Response
+      )
+      expect(mockResponse.sendStatus).toHaveBeenCalledWith(204)
+    })
+
+    it('should handle error when deleting a comment', async () => {
+      commentService.deleteComment.mockRejectedValue(new Error('Delete comment error'))
+      mockRequest.params = { id: 'commentId123' }
+
+      await commentController.deleteComment(
+        mockRequest as Request,
+        mockResponse as Response
+      )
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400)
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: 'Delete comment error',
+      })
+    })
+  })
+})


### PR DESCRIPTION
このプルリクエストでは、新たにコメント機能を追加し、それに対応するデータベースのマイグレーションを行いました。具体的には、以下の作業を実装しました：

投稿に対する全コメントの取得
特定のコメントの取得
新規コメントの作成
コメントの更新
コメントの削除
そして以下のデータベースの変更も行いました：

コメントテーブルの追加
関連する投稿テーブルへの外部キーの追加
それぞれの機能について、ControllerとServiceの実装を行い、適切なエラーハンドリングを含めたテストも実施しました。また、データベースのマイグレーションについても確認済みです。